### PR TITLE
hotfix: fix compiling error on hard_pwm.c

### DIFF
--- a/src/stm32/hard_pwm.c
+++ b/src/stm32/hard_pwm.c
@@ -21,10 +21,10 @@ struct gpio_pwm_info {
 
 static const struct gpio_pwm_info pwm_regs[] = {
 #if CONFIG_MACH_STM32F0
-   #if CONFIG_MACH_STM32F0x2
-    {TIM3, GPIO('B', 4), 1, GPIO_FUNCTION(1)}
-   #endif
-   #if CONFIG_MACH_STM32F070
+  #if CONFIG_MACH_STM32F0x2
+    {TIM3, GPIO('B', 4), 1, GPIO_FUNCTION(1)},
+  #endif
+  #if CONFIG_MACH_STM32F070
     {TIM15, GPIO('A', 2), 1, GPIO_FUNCTION(0)},
     {TIM15, GPIO('A', 3), 2, GPIO_FUNCTION(0)},
     {TIM14, GPIO('A', 4), 1, GPIO_FUNCTION(4)},


### PR DESCRIPTION
Fix compile errors after aea0278

Error message:
```bash
Compiling out/src/stm32/hard_pwm.o
src/stm32/hard_pwm.c:51:5: error: expected '}' before '{' token
   51 |     {TIM2, GPIO('A', 1), 2, GPIO_FUNCTION(2)},
      |     ^
src/stm32/hard_pwm.c:22:48: note: to match this '{'
   22 | static const struct gpio_pwm_info pwm_regs[] = {
      |                     
```

## Checklist

- [ ] pr title makes sense
- [ ] added a test case if possible
- [ ] if new feature, added to the readme
- [ ] ci is happy and green
